### PR TITLE
add assessment schema

### DIFF
--- a/assessment/dev/context.jsonld
+++ b/assessment/dev/context.jsonld
@@ -1,0 +1,113 @@
+{
+    "@context": {
+        "schema": "http://schema.org/",
+        "rsqa": "https://w3id.org/everse/rsqa#",
+        "rsqi": "https://w3id.org/everse/rsqi#",
+        "rs": "https://w3id.org/everse/rs#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "dcterms": "http://purl.org/dc/terms/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "name": "schema:name",
+        "description": "schema:description",
+        "creator": "schema:creator",
+        "dateCreated": "schema:dateCreated",
+        "version": "schema:version",
+        "license": { "@id": "schema:license", "@type": "@id" },
+        "checks": { "@id": "rsqa:hasCheckResult", "@type": "@id" },
+        "status": { "@id": "schema:actionStatus", "@type": "@id" },
+        "process": { "@id": "schema:actionProcess", "@type": "@id" },
+        "output": "rsqa:checkOutput",
+        "evidence": "rsqa:checkEvidence",
+        "SoftwareQualityAssessment": "rsqa:SoftwareQualityAssessment",
+        "CheckResult": "rsqa:CheckResult",
+        "assessedSoftware": { "@id": "rsqa:assessedSoftware", "@type": "@id" },
+        "checkingSoftware": { "@id": "rsqa:checkingSoftware", "@type": "@id" },
+        "assessesIndicator": { "@id": "rsqa:assessesIndicator", "@type": "@id" }
+    },
+    "@graph": [
+        {
+            "@id": "rsqa:SoftwareQualityAssessment",
+            "@type": "rdfs:Class",
+            "rdfs:label": "Software Quality Assessment",
+            "rdfs:comment": "A software quality assessment represents the result of measured indicators for a piece of software."
+        },
+        {
+            "@id": "rsqa:hasCheckResult",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:hasPart" },
+            "rdfs:label": "has check result",
+            "rdfs:comment": "Property that links a software quality assessment to its individual check results.",
+            "rdfs:domain": { "@id": "rsqa:SoftwareQualityAssessment" },
+            "rdfs:range": { "@id": "rsqa:CheckResult" }
+        },
+        {
+            "@id": "rsqa:assessedSoftware",
+            "@type": "rdf:Property",
+            "rdfs:label": "assessed software",
+            "rdfs:comment": "Property that links a SoftwareQualityAssessment to the SoftwareApplication that was assessed.",
+            "rdfs:domain": { "@id": "rsqa:SoftwareQualityAssessment" },
+            "rdfs:range": { "@id": "rs:SoftwareApplication" }
+        },
+        {
+            "@id": "rsqa:CheckResult",
+            "@type": "rdfs:Class",
+            "rdfs:subClassOf": { "@id": "schema:Action" },
+            "rdfs:label": "Check Result",
+            "rdfs:comment": "Represents the outcome of a specific check performed as part of a software quality assessment. It is a subclass of schema:Action."
+        },
+        {
+            "@id": "rsqa:checkingSoftware",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:agent" },
+            "rdfs:label": "checking software",
+            "rdfs:comment": "The software that was used to perform the check.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "rs:SoftwareApplication" }
+        },
+        {
+            "@id": "rsqa:assessesIndicator",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:object" },
+            "rdfs:label": "assesses indicator",
+            "rdfs:comment": "The specific quality indicator that this check assesses.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "rsqi:SoftwareQualityIndicator" }
+        },
+        {
+            "@id": "rsqa:checkOutput",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:result" },
+            "rdfs:label": "check output",
+            "rdfs:comment": "The raw output or result value of the check.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "xsd:string" }
+        },
+        {
+            "@id": "rsqa:checkEvidence",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:result" },
+            "rdfs:label": "check evidence",
+            "rdfs:comment": "Additional information or evidence on how the check status was concluded.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "xsd:string" }
+        },
+        {
+            "@id": "https://w3id.org/everse/rsqa#",
+            "@type": "owl:Ontology",
+            "dcterms:creator": [
+                "Faruk Diblen",
+                "EVERSE Project"
+            ],
+            "dcterms:created": {
+                "@value": "2025-06-19T17:30:00Z",
+                "@type": "xsd:dateTime"
+            },
+            "owl:versionInfo": "0.0.1",
+            "rdfs:label": "Research Software Quality Assessment vocabulary",
+            "owl:versionIRI": { "@id": "https://w3id.org/everse/rsqa/0.0.1" },
+            "license": { "@id": "https://creativecommons.org/licenses/by/4.0/" }
+        }
+    ]
+}

--- a/assessment/dev/example.json
+++ b/assessment/dev/example.json
@@ -1,0 +1,53 @@
+{
+    "@context": "https://w3id.org/everse/rsqa/0.0.1/",
+    "@type": "SoftwareQualityAssessment",
+    "name": "Quality Assessment for CFFinit v2.3.1",
+    "description": "An automated assessment of the CFFinit tool based on the EVERSE software quality indicators, run on 2025-06-19.",
+    "creator": {
+        "@type": "schema:Person",
+        "name": "Faruk Diblen",
+        "email": "f.diblen@example.com"
+    },
+    "dateCreated": "2025-06-19T17:52:00Z",
+    "license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" },
+    "assessedSoftware": {
+        "@type": "schema:SoftwareApplication",
+        "name": "CFFinit",
+        "softwareVersion": "2.3.1",
+        "url": "https://github.com/citation-file-format/cff-initializer-javascript",
+        "schema:identifier": {
+            "@id": "https://doi.org/10.5281/zenodo.8224012"
+        }
+    },
+    "checks": [
+        {
+            "@type": "CheckResult",
+            "assessesIndicator": { "@id": "https://w3id.org/everse/i/indicators/license" },
+            "checkingSoftware": {
+                "@type": "schema:SoftwareApplication",
+                "name": "howfairis",
+                "@id": "https://w3id.org/everse/tools/howfairis",
+                "softwareVersion": "0.14.2"
+            },
+            "process": "Searches for a file named 'LICENSE' or 'LICENSE.md' in the repository root.",
+            "status": { "@id": "schema:CompletedActionStatus" },
+            "output": "true",
+            "evidence": "Found license file: 'LICENSE'."
+        },
+        {
+            "@type": "CheckResult",
+            "assessesIndicator": { "@id": "https://w3id.org/everse/i/indicators/citation" },
+            "checkingSoftware": {
+                "@type": "schema:SoftwareApplication",
+                "name": "howfairis",
+                "@id": "https://w3id.org/everse/tools/howfairis",
+                "softwareVersion": "0.14.2"
+            },
+
+            "process": "Searches for a 'CITATION.cff' file in the repository root and validates its syntax.",
+            "status": { "@id": "schema:CompletedActionStatus" },
+            "output": "valid",
+            "evidence": "Found valid CITATION.cff file in repository root."
+        }
+    ]
+}


### PR DESCRIPTION
**Description:**

This pull request introduces the Research Software Quality Assessment (RSQA) vocabulary, a new JSON-LD schema for describing the results of software quality checks.

The goal is to provide a standardized, machine-readable format for reporting quality metrics. The schema is deeply integrated with Schema.org by subclassing schema:Action and reusing standard properties to ensure maximum interoperability.

**This PR includes:**

The formal JSON-LD vocabulary definition (context.jsonld).
A comprehensive example file (example.json) demonstrating its usage.

**Notes for reviewers:**

The websites /web applications below might be useful.

- https://json-ld.org/playground
- https://validator.schema.org
- https://schema.org/

**Related issues/discussions:**

- #16
- #36 
- #28 

ping: @dgarijo @vuillaut @tamasgal @kaygraf 