### PR TITLE
Simplify software schema

### DIFF
--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -51,7 +51,7 @@
       "rdfs:label": "has quality indicator",
       "rdfs:comment": "Property that links a software application with its corresponding quality indicators.",
       "schema:domainIncludes": { "@id": "SoftwareApplication" },
-      "rangeIncludes": { "@id": "SoftwareQualityIndicator" }
+      "schema:rangeIncludes": { "@id": "SoftwareQualityIndicator" }
     },
     {
       "@id": "howToUse",

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -74,7 +74,7 @@
       "@type": "rdf:Property",
       "rdfs:label": "Applies to programming language",
       "rdfs:comment": "Property that indicates how a software tool applies to a given programming language.",
-      "domainIncludes": { "@id": "SoftwareApplication" },
+      "schema:domainIncludes": { "@id": "SoftwareApplication" },
       "rangeIncludes": { "@id": "schema:Text" }
     },
     {

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -1,26 +1,38 @@
 {
   "@context": {
     "schema": "http://schema.org/",
-    "rsqd" : "https://w3id.org/everse/rsqd#",
-    "rsqi" : "https://w3id.org/everse/rsqi#",
-    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
-    "rdf"  : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-    "owl"  : "http://www.w3.org/2002/07/owl#",
-    "codemeta" : "https://w3id/org/codemeta/",
-    "rs" : "https://w3id.org/everse/rs#",
-    
-    "SoftwareQualityIndicator": { "@id": "rsqi:SoftwareQualityIndicator"}, 
-    "SoftwareQualityDimension": { "@id": "rsqd:SoftwareQualityDimension"},    
-    "SoftwareApplication": { "@id": "schema:SoftwareApplication"},
-    "applicationCategory": { "@id": "schema:applicationCategory", "@type": "@id"},
-    "author": { "@id": "schema:author", "@type": "@id"},
-    "description": { "@id": "schema:description", "@type": "schema:Text"},
-    "name": { "@id": "schema:name", "@type": "schema:Text"},
-    "url": { "@id": "schema:url", "@type": "schema:URL"},
-    "identifier": { "@id": "schema:identifier", "@type": "@id"},
-    "isAccessibleForFree": { "@id": "schema:isAccessibleForFree"},
-    "license": { "@id": "schema:license", "@type": "@id"},
-    "maintainer": { "@id": "codemeta:maintainer" }
+    "rsqd": "https://w3id.org/everse/rsqd#",
+    "rsqi": "https://w3id.org/everse/rsqi#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "codemeta": "https://w3id/org/codemeta/",
+    "rs": "https://w3id.org/everse/rs#",
+
+    "SoftwareQualityIndicator": "rsqi:SoftwareQualityIndicator",
+    "SoftwareQualityDimension": "rsqd:SoftwareQualityDimension",
+    "SoftwareApplication": "schema:SoftwareApplication",
+    "applicationCategory": { "@id": "schema:applicationCategory", "@type": "@id" },
+    "author": { "@id": "schema:author", "@type": "@id" },
+    "description": "schema:description",
+    "name": "schema:name",
+    "url": { "@id": "schema:url", "@type": "@id" },
+    "identifier": { "@id": "schema:identifier", "@type": "@id" },
+    "isAccessibleForFree": "schema:isAccessibleForFree",
+    "license": { "@id": "schema:license", "@type": "@id" },
+    "maintainer": "codemeta:maintainer",
+
+    "hasQualityDimension": { "@id": "rs:hasQualityDimension", "@type": "@id" },
+    "hasQualityIndicator": { "@id": "rs:hasQualityIndicator", "@type": "@id" },
+    "howToUse": { "@id": "rs:howToUse", "@type": "@id" },
+    "usedBy": { "@id": "rs:usedBy", "@type": "@id" },
+    "appliesToProgrammingLanguage": { "@id": "rs:appliesToProgrammingLanguage", "@type": "@id" },
+    "FAIRness": { "@id": "rs:FAIRness", "@type": "@id" },
+    "Sustainability": { "@id": "rs:Sustainability", "@type": "@id" },
+    "Openness": { "@id": "rs:Openness", "@type": "@id" },
+    "AnalysisCode": { "@id": "rs:AnalysisCode", "@type": "@id" },
+    "PrototypeTool": { "@id": "rs:PrototypeTool", "@type": "@id" },
+    "ResearchInfrastructureSoftware": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id" }
   },
   "@graph": [
     {
@@ -28,40 +40,40 @@
       "@type": "rdf:Property",
       "rdfs:label": "has quality dimension",
       "rdfs:comment": "Property designed to link a software tool with its corresponding quality dimensions.",
-      "schema:domainIncludes": {"@id": "schema:SoftwareApplication"},
-      "schema:rangeIncludes": {"@id": "rsqd:SoftwareQualityDimension"}
+      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
+      "schema:rangeIncludes": { "@id": "rsqd:SoftwareQualityDimension" }
     },
     {
       "@id": "rs:hasQualityIndicator",
       "@type": "rdf:Property",
       "rdfs:label": "has quality indicator",
       "rdfs:comment": "Property that links a software application with its corresponding quality indicators.",
-      "schema:domainIncludes": {"@id": "schema:SoftwareApplication"},
-      "schema:rangeIncludes": {"@id": "rsqi:SoftwareQualityIndicator"}
+      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
+      "schema:rangeIncludes": { "@id": "rsqi:SoftwareQualityIndicator" }
     },
     {
       "@id": "rs:howToUse",
       "@type": "rdf:Property",
       "rdfs:label": "howToUse",
       "rdfs:comment": "Property that indicates how a software application is expected to be used (command line, CI/CD, service, etc.).",
-      "schema:domainIncludes": {"@id": "schema:SoftwareApplication"},
-      "schema:rangeIncludes": {"@id": "schema:Text"}
+      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
+      "schema:rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "rs:usedBy",
       "@type": "rdf:Property",
       "rdfs:label": "Used by",
       "rdfs:comment": "Property that indicates how a software application is used by a science cluster.",
-      "schema:domainIncludes": {"@id": "schema:SoftwareApplication"},
-      "schema:rangeIncludes": {"@id": "schema:Text"}
+      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
+      "schema:rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "rs:appliesToProgrammingLanguage",
       "@type": "rdf:Property",
       "rdfs:label": "Applies to programming language",
       "rdfs:comment": "Property that indicates how a software tool applies to a given programming language.",
-      "schema:domainIncludes": {"@id": "schema:SoftwareApplication"},
-      "schema:rangeIncludes": {"@id": "schema:Text"}
+      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
+      "schema:rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "rs:FAIRness",
@@ -96,15 +108,15 @@
       "rdfs:label": "Research infrasturcture software",
       "rdfs:comment": "Software tier type used to categorize mature tools that are used by one or several Research Infrastructures and/or science communities"
     },
-     {
-      "@id" : "https://w3id.org/everse/rs#",
-      "@type" : [ "http://www.w3.org/2002/07/owl#Ontology" ],
-      "creator" : [ "Daniel Garijo", "Thomas Villaume", "EVERSE Project" ],
-      "schema:dateCreated":"2025-01-20T09:00:00",
-      "name":"EVERSE Research Software vocabulary",
-      "identifier": {"@id": "https://w3id.org/everse/rs#", "@type": "@id"},
-      "owl:versionIRI": {"@id": "https://w3id.org/everse/rs/0.0.1", "@type": "@id"},
-      "license": {"@id": "https://creativecommons.org/licenses/by/4.0/", "@type": "@id"}
-     }
+    {
+      "@id": "https://w3id.org/everse/rs#",
+      "@type": [ "http://www.w3.org/2002/07/owl#Ontology" ],
+      "creator": [ "Daniel Garijo", "Thomas Villaume", "EVERSE Project" ],
+      "schema:dateCreated": "2025-01-20T09:00:00",
+      "name": "EVERSE Research Software vocabulary",
+      "identifier": { "@id": "https://w3id.org/everse/rs#", "@type": "@id" },
+      "owl:versionIRI": { "@id": "https://w3id.org/everse/rs/0.0.1", "@type": "@id" },
+      "license": { "@id": "https://creativecommons.org/licenses/by/4.0/", "@type": "@id" }
+    }
   ]
 }

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -10,7 +10,7 @@
     "rs": "https://w3id.org/everse/rs#",
 
     "SoftwareQualityIndicator": { "@id": "rsqi:SoftwareQualityIndicator"}, 
-    "SoftwareQualityDimension": "rsqd:SoftwareQualityDimension",
+    "SoftwareQualityDimension": { "@id": "rsqd:SoftwareQualityDimension"},
     "maintainer": { "@id": "codemeta:maintainer" },
 
      "SoftwareApplication": {"@id": "schema:SoftwareApplication"},

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -42,7 +42,7 @@
       "@type": "rdf:Property",
       "rdfs:label": "has quality dimension",
       "rdfs:comment": "Property designed to link a software tool with its corresponding quality dimensions.",
-      "domainIncludes": { "@id": "SoftwareApplication" },
+      "schema:domainIncludes": { "@id": "SoftwareApplication" },
       "rangeIncludes": { "@id": "SoftwareQualityDimension" }
     },
     {

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -13,7 +13,7 @@
     "SoftwareQualityDimension": "rsqd:SoftwareQualityDimension",
     "maintainer": { "@id": "codemeta:maintainer" },
 
-    "SoftwareApplication": "schema:SoftwareApplication",
+     "SoftwareApplication": {"@id": "schema:SoftwareApplication"},
     "applicationCategory": { "@id": "schema:applicationCategory", "@type": "@id" },
     "author": { "@id": "schema:author", "@type": "@id" },
     "description": "schema:description",

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -9,11 +9,11 @@
     "codemeta": "https://w3id/org/codemeta/",
     "rs": "https://w3id.org/everse/rs#",
 
-    "SoftwareQualityIndicator": { "@id": "rsqi:SoftwareQualityIndicator"}, 
-    "SoftwareQualityDimension": { "@id": "rsqd:SoftwareQualityDimension"},
+    "SoftwareQualityIndicator": { "@id": "rsqi:SoftwareQualityIndicator" },
+    "SoftwareQualityDimension": { "@id": "rsqd:SoftwareQualityDimension" },
     "maintainer": { "@id": "codemeta:maintainer" },
 
-     "SoftwareApplication": {"@id": "schema:SoftwareApplication"},
+    "SoftwareApplication": { "@id": "schema:SoftwareApplication" },
     "applicationCategory": { "@id": "schema:applicationCategory", "@type": "@id" },
     "author": { "@id": "schema:author", "@type": "@id" },
     "description": "schema:description",
@@ -29,8 +29,9 @@
     "howToUse": { "@id": "rs:howToUse", "@type": "@id" },
     "usedBy": { "@id": "rs:usedBy", "@type": "@id" },
     "appliesToProgrammingLanguage": { "@id": "rs:appliesToProgrammingLanguage", "@type": "@id" },
-    "Sustainability": { "@id": "rs:Sustainability", "@type": "@id" },
-    "Openness": { "@id": "rs:Openness", "@type": "@id" },
+    "FAIRness": { "@id": "FAIRness", "@type": "@id" },
+    "Sustainability": { "@id": "Sustainability", "@type": "@id" },
+    "Openness": { "@id": "Openness", "@type": "@id" },
     "AnalysisCode": { "@id": "rs:AnalysisCode", "@type": "@id" },
     "PrototypeTool": { "@id": "rs:PrototypeTool", "@type": "@id" },
     "ResearchInfrastructureSoftware": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id" }

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -58,7 +58,7 @@
       "@type": "rdf:Property",
       "rdfs:label": "howToUse",
       "rdfs:comment": "Property that indicates how a software application is expected to be used (command line, CI/CD, service, etc.).",
-      "domainIncludes": { "@id": "SoftwareApplication" },
+      "schema:domainIncludes": { "@id": "SoftwareApplication" },
       "schema:rangeIncludes": { "@id": "schema:Text" }
     },
     {

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -11,7 +11,7 @@
 
     "SoftwareQualityIndicator": "rsqi:SoftwareQualityIndicator",
     "SoftwareQualityDimension": "rsqd:SoftwareQualityDimension",
-    "maintainer": "codemeta:maintainer",
+    "maintainer": { "@id": "codemeta:maintainer" },
 
     "SoftwareApplication": "schema:SoftwareApplication",
     "applicationCategory": { "@id": "schema:applicationCategory", "@type": "@id" },

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -29,7 +29,6 @@
     "howToUse": { "@id": "rs:howToUse", "@type": "@id" },
     "usedBy": { "@id": "rs:usedBy", "@type": "@id" },
     "appliesToProgrammingLanguage": { "@id": "rs:appliesToProgrammingLanguage", "@type": "@id" },
-    "FAIRness": { "@id": "rs:FAIRness", "@type": "@id" },
     "Sustainability": { "@id": "rs:Sustainability", "@type": "@id" },
     "Openness": { "@id": "rs:Openness", "@type": "@id" },
     "AnalysisCode": { "@id": "rs:AnalysisCode", "@type": "@id" },

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -20,6 +20,11 @@
     "identifier": { "@id": "schema:identifier", "@type": "@id" },
     "isAccessibleForFree": "schema:isAccessibleForFree",
     "license": { "@id": "schema:license", "@type": "@id" },
+    "dateCreated": { "@id": "schema:dateCreated", "@type": "@id" },
+    "domainIncludes": { "@id": "schema:SoftwareApplication", "@type": "@id" },
+
+    "rangeIncludes": { "@id": "rsqd:SoftwareQualityDimension", "@type": "@id" },
+
     "maintainer": "codemeta:maintainer",
 
     "hasQualityDimension": { "@id": "rs:hasQualityDimension", "@type": "@id" },
@@ -40,40 +45,40 @@
       "@type": "rdf:Property",
       "rdfs:label": "has quality dimension",
       "rdfs:comment": "Property designed to link a software tool with its corresponding quality dimensions.",
-      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
-      "schema:rangeIncludes": { "@id": "rsqd:SoftwareQualityDimension" }
+      "domainIncludes": { "@id": "SoftwareApplication" },
+      "rangeIncludes": { "@id": "rsqd:SoftwareQualityDimension" }
     },
     {
       "@id": "rs:hasQualityIndicator",
       "@type": "rdf:Property",
       "rdfs:label": "has quality indicator",
       "rdfs:comment": "Property that links a software application with its corresponding quality indicators.",
-      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
-      "schema:rangeIncludes": { "@id": "rsqi:SoftwareQualityIndicator" }
+      "domainIncludes": { "@id": "SoftwareApplication" },
+      "rangeIncludes": { "@id": "rsqi:SoftwareQualityIndicator" }
     },
     {
       "@id": "rs:howToUse",
       "@type": "rdf:Property",
       "rdfs:label": "howToUse",
       "rdfs:comment": "Property that indicates how a software application is expected to be used (command line, CI/CD, service, etc.).",
-      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
-      "schema:rangeIncludes": { "@id": "schema:Text" }
+      "domainIncludes": { "@id": "SoftwareApplication" },
+      "rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "rs:usedBy",
       "@type": "rdf:Property",
       "rdfs:label": "Used by",
       "rdfs:comment": "Property that indicates how a software application is used by a science cluster.",
-      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
-      "schema:rangeIncludes": { "@id": "schema:Text" }
+      "domainIncludes": { "@id": "SoftwareApplication" },
+      "rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "rs:appliesToProgrammingLanguage",
       "@type": "rdf:Property",
       "rdfs:label": "Applies to programming language",
       "rdfs:comment": "Property that indicates how a software tool applies to a given programming language.",
-      "schema:domainIncludes": { "@id": "schema:SoftwareApplication" },
-      "schema:rangeIncludes": { "@id": "schema:Text" }
+      "domainIncludes": { "@id": "SoftwareApplication" },
+      "rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "rs:FAIRness",
@@ -112,7 +117,7 @@
       "@id": "https://w3id.org/everse/rs#",
       "@type": [ "http://www.w3.org/2002/07/owl#Ontology" ],
       "creator": [ "Daniel Garijo", "Thomas Villaume", "EVERSE Project" ],
-      "schema:dateCreated": "2025-01-20T09:00:00",
+      "dateCreated": "2025-01-20T09:00:00",
       "name": "EVERSE Research Software vocabulary",
       "identifier": { "@id": "https://w3id.org/everse/rs#", "@type": "@id" },
       "owl:versionIRI": { "@id": "https://w3id.org/everse/rs/0.0.1", "@type": "@id" },

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -43,7 +43,7 @@
       "rdfs:label": "has quality dimension",
       "rdfs:comment": "Property designed to link a software tool with its corresponding quality dimensions.",
       "schema:domainIncludes": { "@id": "SoftwareApplication" },
-      "rangeIncludes": { "@id": "SoftwareQualityDimension" }
+      "schema:rangeIncludes": { "@id": "SoftwareQualityDimension" }
     },
     {
       "@id": "hasQualityIndicator",

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -66,8 +66,8 @@
       "@type": "rdf:Property",
       "rdfs:label": "Used by",
       "rdfs:comment": "Property that indicates how a software application is used by a science cluster.",
-      "domainIncludes": { "@id": "SoftwareApplication" },
-      "rangeIncludes": { "@id": "schema:Text" }
+      "schema:domainIncludes": { "@id": "SoftwareApplication" },
+      "schema:rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "appliesToProgrammingLanguage",

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -9,7 +9,7 @@
     "codemeta": "https://w3id/org/codemeta/",
     "rs": "https://w3id.org/everse/rs#",
 
-    "SoftwareQualityIndicator": "rsqi:SoftwareQualityIndicator",
+    "SoftwareQualityIndicator": { "@id": "rsqi:SoftwareQualityIndicator"}, 
     "SoftwareQualityDimension": "rsqd:SoftwareQualityDimension",
     "maintainer": { "@id": "codemeta:maintainer" },
 

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -113,7 +113,7 @@
     {
       "@id": "https://w3id.org/everse/rs#",
       "@type": [ "http://www.w3.org/2002/07/owl#Ontology" ],
-      "creator": [ "Daniel Garijo", "Thomas Villaume", "Faruk Diblen", "EVERSE Project" ],
+      "creator": [ "Daniel Garijo", "Thomas Vuillaume", "Faruk Diblen", "EVERSE Project" ],
       "dateCreated": "2025-01-20T09:00:00",
       "name": "EVERSE Research Software vocabulary",
       "identifier": { "@id": "https://w3id.org/everse/rs#", "@type": "@id" },

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -75,7 +75,7 @@
       "rdfs:label": "Applies to programming language",
       "rdfs:comment": "Property that indicates how a software tool applies to a given programming language.",
       "schema:domainIncludes": { "@id": "SoftwareApplication" },
-      "rangeIncludes": { "@id": "schema:Text" }
+      "schema:rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "FAIRness",

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -59,7 +59,7 @@
       "rdfs:label": "howToUse",
       "rdfs:comment": "Property that indicates how a software application is expected to be used (command line, CI/CD, service, etc.).",
       "domainIncludes": { "@id": "SoftwareApplication" },
-      "rangeIncludes": { "@id": "schema:Text" }
+      "schema:rangeIncludes": { "@id": "schema:Text" }
     },
     {
       "@id": "usedBy",

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -11,6 +11,8 @@
 
     "SoftwareQualityIndicator": "rsqi:SoftwareQualityIndicator",
     "SoftwareQualityDimension": "rsqd:SoftwareQualityDimension",
+    "maintainer": "codemeta:maintainer",
+
     "SoftwareApplication": "schema:SoftwareApplication",
     "applicationCategory": { "@id": "schema:applicationCategory", "@type": "@id" },
     "author": { "@id": "schema:author", "@type": "@id" },
@@ -21,11 +23,6 @@
     "isAccessibleForFree": "schema:isAccessibleForFree",
     "license": { "@id": "schema:license", "@type": "@id" },
     "dateCreated": { "@id": "schema:dateCreated", "@type": "@id" },
-    "domainIncludes": { "@id": "schema:SoftwareApplication", "@type": "@id" },
-
-    "rangeIncludes": { "@id": "rsqd:SoftwareQualityDimension", "@type": "@id" },
-
-    "maintainer": "codemeta:maintainer",
 
     "hasQualityDimension": { "@id": "rs:hasQualityDimension", "@type": "@id" },
     "hasQualityIndicator": { "@id": "rs:hasQualityIndicator", "@type": "@id" },
@@ -41,23 +38,23 @@
   },
   "@graph": [
     {
-      "@id": "rs:hasQualityDimension",
+      "@id": "hasQualityDimension",
       "@type": "rdf:Property",
       "rdfs:label": "has quality dimension",
       "rdfs:comment": "Property designed to link a software tool with its corresponding quality dimensions.",
       "domainIncludes": { "@id": "SoftwareApplication" },
-      "rangeIncludes": { "@id": "rsqd:SoftwareQualityDimension" }
+      "rangeIncludes": { "@id": "SoftwareQualityDimension" }
     },
     {
-      "@id": "rs:hasQualityIndicator",
+      "@id": "hasQualityIndicator",
       "@type": "rdf:Property",
       "rdfs:label": "has quality indicator",
       "rdfs:comment": "Property that links a software application with its corresponding quality indicators.",
       "domainIncludes": { "@id": "SoftwareApplication" },
-      "rangeIncludes": { "@id": "rsqi:SoftwareQualityIndicator" }
+      "rangeIncludes": { "@id": "SoftwareQualityIndicator" }
     },
     {
-      "@id": "rs:howToUse",
+      "@id": "howToUse",
       "@type": "rdf:Property",
       "rdfs:label": "howToUse",
       "rdfs:comment": "Property that indicates how a software application is expected to be used (command line, CI/CD, service, etc.).",
@@ -65,7 +62,7 @@
       "rangeIncludes": { "@id": "schema:Text" }
     },
     {
-      "@id": "rs:usedBy",
+      "@id": "usedBy",
       "@type": "rdf:Property",
       "rdfs:label": "Used by",
       "rdfs:comment": "Property that indicates how a software application is used by a science cluster.",
@@ -73,7 +70,7 @@
       "rangeIncludes": { "@id": "schema:Text" }
     },
     {
-      "@id": "rs:appliesToProgrammingLanguage",
+      "@id": "appliesToProgrammingLanguage",
       "@type": "rdf:Property",
       "rdfs:label": "Applies to programming language",
       "rdfs:comment": "Property that indicates how a software tool applies to a given programming language.",
@@ -81,42 +78,42 @@
       "rangeIncludes": { "@id": "schema:Text" }
     },
     {
-      "@id": "rs:FAIRness",
-      "@type": "rsqd:SoftwareQualityDimension",
+      "@id": "FAIRness",
+      "@type": "SoftwareQualityDimension",
       "rdfs:label": "FAIRness",
       "rdfs:comment": "Quality dimension related to the compliance of a software tool with the Findable, Accessible, Interoperable and Reusable (FAIR) principles."
     },
     {
-      "@id": "rs:Sustainability",
-      "@type": "rsqd:SoftwareQualityDimension",
+      "@id": "Sustainability",
+      "@type": "SoftwareQualityDimension",
       "rdfs:label": "Sustainability",
       "rdfs:comment": "Quality dimension related to the compliance of a software tool with aspects related to Functional sustainability, Reproducibility, Long-term usability, Portability, Maintainability, Documentation, Usability, Code analysis, Security, Community and Resource efficiency."
     },
     {
-      "@id": "rs:Openness",
-      "@type": "rsqd:SoftwareQualityDimension",
+      "@id": "Openness",
+      "@type": "SoftwareQualityDimension",
       "rdfs:label": "Openness",
       "rdfs:comment": "Quality dimension related to the compliance of a software tool with best practices for Open Source."
     },
     {
-      "@id": "rs:AnalysisCode",
+      "@id": "AnalysisCode",
       "rdfs:label": "Analysis Code",
       "rdfs:comment": "Software tier type used to categorize scripts and tools designed to support a research publication or investigation, with a low level of maturity"
     },
     {
-      "@id": "rs:PrototypeTool",
+      "@id": "PrototypeTool",
       "rdfs:label": "Prototype tool",
       "rdfs:comment": "Software tier type used to categorize tools designed to support a research publication or investigation that have reached a level of maturity and reuse among the community"
     },
     {
-      "@id": "rs:ResearchInfrastructureSoftware",
+      "@id": "ResearchInfrastructureSoftware",
       "rdfs:label": "Research infrasturcture software",
       "rdfs:comment": "Software tier type used to categorize mature tools that are used by one or several Research Infrastructures and/or science communities"
     },
     {
       "@id": "https://w3id.org/everse/rs#",
       "@type": [ "http://www.w3.org/2002/07/owl#Ontology" ],
-      "creator": [ "Daniel Garijo", "Thomas Villaume", "EVERSE Project" ],
+      "creator": [ "Daniel Garijo", "Thomas Villaume", "Faruk Diblen", "EVERSE Project" ],
       "dateCreated": "2025-01-20T09:00:00",
       "name": "EVERSE Research Software vocabulary",
       "identifier": { "@id": "https://w3id.org/everse/rs#", "@type": "@id" },

--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -50,7 +50,7 @@
       "@type": "rdf:Property",
       "rdfs:label": "has quality indicator",
       "rdfs:comment": "Property that links a software application with its corresponding quality indicators.",
-      "domainIncludes": { "@id": "SoftwareApplication" },
+      "schema:domainIncludes": { "@id": "SoftwareApplication" },
       "rangeIncludes": { "@id": "SoftwareQualityIndicator" }
     },
     {

--- a/software/dev/example.json
+++ b/software/dev/example.json
@@ -9,5 +9,5 @@
   "isAccessibleForFree": true,
   "hasQualityDimension": "FAIRness",
   "howToUse": [ "CI/CD", "command-line" ],
-  "license": "https://spdx.org/licenses/Apache-2.0.html"
+  "license": "https://spdx.org/licenses/Apache-2.0"
 }

--- a/software/dev/example.json
+++ b/software/dev/example.json
@@ -1,6 +1,5 @@
 {
   "@context": {
-    "schema": "http://schema.org/",
     "rs": "https://w3id.org/everse/rs#"
   },
   "@id": "https://example.org/howfairis",

--- a/software/dev/example.json
+++ b/software/dev/example.json
@@ -7,7 +7,7 @@
   "url": "https://github.com/fair-software/howfairis",
   "identifier": "https://example.org/howfairis",
   "isAccessibleForFree": true,
-  "hasQualityDimension": "FAIRness",
+  "hasQualityDimension": { "@id": "FAIRness", "@type": "@id" },
   "howToUse": [ "CI/CD", "command-line" ],
-  "license": {"@id": "https://spdx.org/licenses/Apache-2.0"}
+  "license": "https://spdx.org/licenses/Apache-2.0"
 }

--- a/software/dev/example.json
+++ b/software/dev/example.json
@@ -9,5 +9,5 @@
   "isAccessibleForFree": true,
   "hasQualityDimension": "FAIRness",
   "howToUse": [ "CI/CD", "command-line" ],
-  "license": "https://spdx.org/licenses/Apache-2.0"
+  "license": {"@id": "https://spdx.org/licenses/Apache-2.0"}
 }

--- a/software/dev/example.json
+++ b/software/dev/example.json
@@ -1,17 +1,16 @@
 {
   "@context": {
     "schema": "http://schema.org/",
-    "rs" : "https://w3id.org/everse/rs#"
+    "rs": "https://w3id.org/everse/rs#"
   },
-      "@id": "https://example.org/howfairis",
-      "@type": "schema:SoftwareApplication",
-  "schema:name": "howfairis",
-  "schema:description": "Command line tool to analyze a GitHub or GitLab repository's compliance with the fair-software.eu recommendations",
-  "schema:url": "https://github.com/fair-software/howfairis",
-  "schema:identifier": { "@id": "https://example.org/howfairis"},
-  "schema:isAccessibleForFree": true,
-  "rs:hasQualityDimension": {"@id":"rs:FAIRness", "@type": "@id"},
-  "rs:howToUse": ["CI/CD","command-line"],
-  "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}
-    
+  "@id": "https://example.org/howfairis",
+  "@type": "SoftwareApplication",
+  "name": "howfairis",
+  "description": "Command line tool to analyze a GitHub or GitLab repository's compliance with the fair-software.eu recommendations",
+  "url": "https://github.com/fair-software/howfairis",
+  "identifier": { "@id": "https://example.org/howfairis" },
+  "isAccessibleForFree": true,
+  "hasQualityDimension": { "@id": "FAIRness", "@type": "@id" },
+  "howToUse": [ "CI/CD", "command-line" ],
+  "license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id" }
 }

--- a/software/dev/example.json
+++ b/software/dev/example.json
@@ -1,15 +1,13 @@
 {
-  "@context": {
-    "rs": "https://w3id.org/everse/rs#"
-  },
+  "@context": "https://w3id.org/everse/rs#",
   "@id": "https://example.org/howfairis",
   "@type": "SoftwareApplication",
   "name": "howfairis",
   "description": "Command line tool to analyze a GitHub or GitLab repository's compliance with the fair-software.eu recommendations",
   "url": "https://github.com/fair-software/howfairis",
-  "identifier": { "@id": "https://example.org/howfairis" },
+  "identifier": "https://example.org/howfairis",
   "isAccessibleForFree": true,
-  "hasQualityDimension": { "@id": "FAIRness", "@type": "@id" },
+  "hasQualityDimension": "FAIRness",
   "howToUse": [ "CI/CD", "command-line" ],
-  "license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id" }
+  "license": "https://spdx.org/licenses/Apache-2.0.html"
 }


### PR DESCRIPTION
This PR simplifies the software schema:
- Removes the need of `rs` prefix
- updates the software example to use the simplified example
- formats the schema (spaces indentation etc.)