### PR TITLE
Introduces ImprovesQualityIndicator and MeasuresQualityIndicator 

### DIFF
--- a/software/dev/context.jsonld
+++ b/software/dev/context.jsonld
@@ -54,7 +54,7 @@
       "schema:rangeIncludes": { "@id": "SoftwareQualityIndicator" }
     },
     {
-      "@id": "rs:ImprovesQualityIndicator",
+      "@id": "rs:improvesQualityIndicator",
       "@type": "rdf:Property",
       "rdfs:label": "improves quality indicator",
       "rdfs:comment": "Property that links a software application with the corresponding quality indicators it improves.",


### PR DESCRIPTION
Introduces `ImprovesQualityIndicator` and `MeasuresQualityIndicator` metadata types to replace `hasQualityIndicator`.

This is needed to provide a better relationship between the software application and the indicators.
I propose to keep it simple with this implementation.

Fixes #50 