### PR TITLE
add documentation for the assessment schema

### DIFF
--- a/assessment/0.0.2/README.md
+++ b/assessment/0.0.2/README.md
@@ -1,0 +1,119 @@
+# RS Quality Assessment metadata schema
+
+- Version: 0.0.2
+- Identifier: https://w3id.org/everse/rsqa#
+- Version identifier: https://w3id.org/everse/rsqa/0.0.2
+- Author: Faruk Diblen, EVERSE Consortium
+
+A repository to describe the Research Software Quality Assessment results used in the EVERSE project. This schema allows for capturing the outcomes of software quality assessments, including individual check results and their associated evidence.
+
+## Namespaces used in this document
+
+| Namespace prefix | Namespace URI                                                  |
+| ---------------- | -------------------------------------------------------------- |
+| rsqa             | [https://w3id.org/everse/rsqa#](https://w3id.org/everse/rsqa#) |
+| rsqi             | [https://w3id.org/everse/rsqi#](https://w3id.org/everse/rsqi#) |
+| rs               | [https://w3id.org/everse/rs#](https://w3id.org/everse/rs#)     |
+| schema           | [http://schema.org/](http://schema.org/)                       |
+| dcterms          | [http://purl.org/dc/terms/](http://purl.org/dc/terms/)         |
+
+## Definitions
+
+### Software Quality Assessment (rsqa:SoftwareQualityAssessment)
+
+A software quality assessment represents the result of measured indicators for a piece of software. It aggregates multiple check results that evaluate different quality indicators.
+
+The following metadata attributes define a Software Quality Assessment:
+
+| Attribute         | Key (JSON-LD)    | Term (mapping)                                                         | Expected value                                                                                       |
+| ----------------- | ---------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Name              | name             | [schema:name](https://schema.org/name)                                 | [schema:Text](https://schema.org/Text) (String)                                                      |
+| Description       | description      | [schema:description](https://schema.org/description)                   | [schema:Text](https://schema.org/Text) (String)                                                      |
+| Creator           | creator          | [schema:creator](https://schema.org/creator)                           | [schema:Person](https://schema.org/Person) or [schema:Organization](https://schema.org/Organization) |
+| Date created      | dateCreated      | [schema:dateCreated](https://schema.org/dateCreated)                   | [schema:DateTime](https://schema.org/DateTime) (String)                                              |
+| Version           | version          | [schema:version](https://schema.org/version)                           | [schema:Text](https://schema.org/Text) (String)                                                      |
+| License           | license          | [schema:license](https://schema.org/license)                           | [schema:URL](https://schema.org/URL) (URL)                                                           |
+| Assessed software | assessedSoftware | [rsqa:assessedSoftware](https://w3id.org/everse/rsqa#assessedSoftware) | [rs:SoftwareApplication](https://w3id.org/everse/rs#SoftwareApplication) (URL)                       |
+| Check results     | checks           | [rsqa:hasCheckResult](https://w3id.org/everse/rsqa#hasCheckResult)     | [rsqa:CheckResult](https://w3id.org/everse/rsqa#CheckResult) (Array)                                 |
+
+### Check Result (rsqa:CheckResult)
+
+Represents the outcome of a specific check performed as part of a software quality assessment. It is a subclass of schema:Action, capturing the process and result of evaluating a particular quality indicator.
+
+The following metadata attributes define a Check Result:
+
+| Attribute          | Key (JSON-LD)     | Term (mapping)                                                           | Expected value                                                                               |
+| ------------------ | ----------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Assesses indicator | assessesIndicator | [rsqa:assessesIndicator](https://w3id.org/everse/rsqa#assessesIndicator) | [rsqi:SoftwareQualityIndicator](https://w3id.org/everse/rsqi#SoftwareQualityIndicator) (URL) |
+| Checking software  | checkingSoftware  | [rsqa:checkingSoftware](https://w3id.org/everse/rsqa#checkingSoftware)   | [rs:SoftwareApplication](https://w3id.org/everse/rs#SoftwareApplication)                     |
+| Process            | process           | [schema:actionProcess](https://schema.org/actionProcess)                 | [schema:Text](https://schema.org/Text) (String)                                              |
+| Status             | status            | [schema:actionStatus](https://schema.org/actionStatus)                   | [schema:ActionStatusType](https://schema.org/ActionStatusType) (URL)                         |
+| Output             | output            | [rsqa:checkOutput](https://w3id.org/everse/rsqa#checkOutput)             | [xsd:string](http://www.w3.org/2001/XMLSchema#string) (String)                               |
+| Evidence           | evidence          | [rsqa:checkEvidence](https://w3id.org/everse/rsqa#checkEvidence)         | [xsd:string](http://www.w3.org/2001/XMLSchema#string) (String)                               |
+
+## Properties
+
+### rsqa:assessedSoftware
+
+Links a SoftwareQualityAssessment to the SoftwareApplication that was assessed.
+
+- Domain: rsqa:SoftwareQualityAssessment
+- Range: rs:SoftwareApplication
+
+### rsqa:hasCheckResult
+
+Links a software quality assessment to its individual check results.
+
+- Domain: rsqa:SoftwareQualityAssessment
+- Range: rsqa:CheckResult
+- SubPropertyOf: schema:hasPart
+
+### rsqa:checkingSoftware
+
+The software that was used to perform the check.
+
+- Domain: rsqa:CheckResult
+- Range: rs:SoftwareApplication
+- SubPropertyOf: schema:agent
+
+### rsqa:assessesIndicator
+
+The specific quality indicator that this check assesses.
+
+- Domain: rsqa:CheckResult
+- Range: rsqi:SoftwareQualityIndicator
+- SubPropertyOf: schema:object
+
+### rsqa:checkOutput
+
+The raw output or result value of the check.
+
+- Domain: rsqa:CheckResult
+- Range: xsd:string
+- SubPropertyOf: schema:result
+
+### rsqa:checkEvidence
+
+Additional information or evidence on how the check status was concluded.
+
+- Domain: rsqa:CheckResult
+- Range: xsd:string
+- SubPropertyOf: schema:result
+
+## Example
+
+To see an example of an assessment, see the [JSON-LD file](example.json) stored in this repository.
+
+The latest version of the vocabulary is accessible at [https://w3id.org/everse/rsqa](https://w3id.org/everse/rsqa).
+
+To obtain the JSON-LD context, just perform content negotiation as follows:
+
+```
+curl -sH "accept:application/ld+json" -L https://w3id.org/everse/rsqa
+```
+
+The vocabulary has versioning enabled. To get a particular version add the version number in the URL:
+
+```
+curl -sH "accept:application/ld+json" -L https://w3id.org/everse/rsqa/0.0.2
+```

--- a/assessment/0.0.2/context.jsonld
+++ b/assessment/0.0.2/context.jsonld
@@ -1,0 +1,113 @@
+{
+    "@context": {
+        "schema": "http://schema.org/",
+        "rsqa": "https://w3id.org/everse/rsqa#",
+        "rsqi": "https://w3id.org/everse/rsqi#",
+        "rs": "https://w3id.org/everse/rs#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "dcterms": "http://purl.org/dc/terms/",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "name": "schema:name",
+        "description": "schema:description",
+        "creator": "schema:creator",
+        "dateCreated": "schema:dateCreated",
+        "version": "schema:version",
+        "license": { "@id": "schema:license", "@type": "@id" },
+        "checks": { "@id": "rsqa:hasCheckResult", "@type": "@id" },
+        "status": { "@id": "schema:actionStatus", "@type": "@id" },
+        "process": { "@id": "schema:actionProcess", "@type": "@id" },
+        "output": "rsqa:checkOutput",
+        "evidence": "rsqa:checkEvidence",
+        "SoftwareQualityAssessment": "rsqa:SoftwareQualityAssessment",
+        "CheckResult": "rsqa:CheckResult",
+        "assessedSoftware": { "@id": "rsqa:assessedSoftware", "@type": "@id" },
+        "checkingSoftware": { "@id": "rsqa:checkingSoftware", "@type": "@id" },
+        "assessesIndicator": { "@id": "rsqa:assessesIndicator", "@type": "@id" }
+    },
+    "@graph": [
+        {
+            "@id": "rsqa:SoftwareQualityAssessment",
+            "@type": "rdfs:Class",
+            "rdfs:label": "Software Quality Assessment",
+            "rdfs:comment": "A software quality assessment represents the result of measured indicators for a piece of software."
+        },
+        {
+            "@id": "rsqa:hasCheckResult",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:hasPart" },
+            "rdfs:label": "has check result",
+            "rdfs:comment": "Property that links a software quality assessment to its individual check results.",
+            "rdfs:domain": { "@id": "rsqa:SoftwareQualityAssessment" },
+            "rdfs:range": { "@id": "rsqa:CheckResult" }
+        },
+        {
+            "@id": "rsqa:assessedSoftware",
+            "@type": "rdf:Property",
+            "rdfs:label": "assessed software",
+            "rdfs:comment": "Property that links a SoftwareQualityAssessment to the SoftwareApplication that was assessed.",
+            "rdfs:domain": { "@id": "rsqa:SoftwareQualityAssessment" },
+            "rdfs:range": { "@id": "rs:SoftwareApplication" }
+        },
+        {
+            "@id": "rsqa:CheckResult",
+            "@type": "rdfs:Class",
+            "rdfs:subClassOf": { "@id": "schema:Action" },
+            "rdfs:label": "Check Result",
+            "rdfs:comment": "Represents the outcome of a specific check performed as part of a software quality assessment. It is a subclass of schema:Action."
+        },
+        {
+            "@id": "rsqa:checkingSoftware",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:agent" },
+            "rdfs:label": "checking software",
+            "rdfs:comment": "The software that was used to perform the check.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "rs:SoftwareApplication" }
+        },
+        {
+            "@id": "rsqa:assessesIndicator",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:object" },
+            "rdfs:label": "assesses indicator",
+            "rdfs:comment": "The specific quality indicator that this check assesses.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "rsqi:SoftwareQualityIndicator" }
+        },
+        {
+            "@id": "rsqa:checkOutput",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:result" },
+            "rdfs:label": "check output",
+            "rdfs:comment": "The raw output or result value of the check.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "xsd:string" }
+        },
+        {
+            "@id": "rsqa:checkEvidence",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:result" },
+            "rdfs:label": "check evidence",
+            "rdfs:comment": "Additional information or evidence on how the check status was concluded.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "xsd:string" }
+        },
+        {
+            "@id": "https://w3id.org/everse/rsqa#",
+            "@type": "owl:Ontology",
+            "dcterms:creator": [
+                "Faruk Diblen",
+                "EVERSE Project"
+            ],
+            "dcterms:created": {
+                "@value": "2025-06-19T17:30:00Z",
+                "@type": "xsd:dateTime"
+            },
+            "owl:versionInfo": "0.0.2",
+            "rdfs:label": "Research Software Quality Assessment vocabulary",
+            "owl:versionIRI": { "@id": "https://w3id.org/everse/rsqa/0.0.2" },
+            "license": { "@id": "https://creativecommons.org/licenses/by/4.0/" }
+        }
+    ]
+}

--- a/assessment/0.0.2/context.jsonld
+++ b/assessment/0.0.2/context.jsonld
@@ -100,7 +100,7 @@
                 "Faruk Diblen",
                 "EVERSE Project"
             ],
-            "dcterms:created": {
+            "schema:dateCreated": {
                 "@value": "2025-06-19T17:30:00Z",
                 "@type": "xsd:dateTime"
             },

--- a/assessment/0.0.2/context.jsonld
+++ b/assessment/0.0.2/context.jsonld
@@ -96,7 +96,7 @@
         {
             "@id": "https://w3id.org/everse/rsqa#",
             "@type": "owl:Ontology",
-            "dcterms:creator": [
+            "schema:creator": [
                 "Faruk Diblen",
                 "EVERSE Project"
             ],

--- a/assessment/0.0.2/context.jsonld
+++ b/assessment/0.0.2/context.jsonld
@@ -102,7 +102,7 @@
             ],
             "schema:dateCreated": {
                 "@value": "2025-06-19T17:30:00Z",
-                "@type": "xsd:dateTime"
+                "@type": "schema:DateTime"
             },
             "owl:versionInfo": "0.0.2",
             "rdfs:label": "Research Software Quality Assessment vocabulary",

--- a/assessment/0.0.2/example.json
+++ b/assessment/0.0.2/example.json
@@ -1,0 +1,53 @@
+{
+    "@context": "https://w3id.org/everse/rsqa/0.0.1/",
+    "@type": "SoftwareQualityAssessment",
+    "name": "Quality Assessment for CFFinit v2.3.1",
+    "description": "An automated assessment of the CFFinit tool based on the EVERSE software quality indicators, run on 2025-06-19.",
+    "creator": {
+        "@type": "schema:Person",
+        "name": "Faruk Diblen",
+        "email": "f.diblen@example.com"
+    },
+    "dateCreated": "2025-06-19T17:52:00Z",
+    "license": { "@id": "https://creativecommons.org/publicdomain/zero/1.0/" },
+    "assessedSoftware": {
+        "@type": "schema:SoftwareApplication",
+        "name": "CFFinit",
+        "softwareVersion": "2.3.1",
+        "url": "https://github.com/citation-file-format/cff-initializer-javascript",
+        "schema:identifier": {
+            "@id": "https://doi.org/10.5281/zenodo.8224012"
+        }
+    },
+    "checks": [
+        {
+            "@type": "CheckResult",
+            "assessesIndicator": { "@id": "https://w3id.org/everse/i/indicators/license" },
+            "checkingSoftware": {
+                "@type": "schema:SoftwareApplication",
+                "name": "howfairis",
+                "@id": "https://w3id.org/everse/tools/howfairis",
+                "softwareVersion": "0.14.2"
+            },
+            "process": "Searches for a file named 'LICENSE' or 'LICENSE.md' in the repository root.",
+            "status": { "@id": "schema:CompletedActionStatus" },
+            "output": "true",
+            "evidence": "Found license file: 'LICENSE'."
+        },
+        {
+            "@type": "CheckResult",
+            "assessesIndicator": { "@id": "https://w3id.org/everse/i/indicators/citation" },
+            "checkingSoftware": {
+                "@type": "schema:SoftwareApplication",
+                "name": "howfairis",
+                "@id": "https://w3id.org/everse/tools/howfairis",
+                "softwareVersion": "0.14.2"
+            },
+
+            "process": "Searches for a 'CITATION.cff' file in the repository root and validates its syntax.",
+            "status": { "@id": "schema:CompletedActionStatus" },
+            "output": "valid",
+            "evidence": "Found valid CITATION.cff file in repository root."
+        }
+    ]
+}

--- a/assessment/dev/README.md
+++ b/assessment/dev/README.md
@@ -1,0 +1,118 @@
+# RS Quality Assessment metadata schema
+- Version: 0.0.1
+- Identifier: https://w3id.org/everse/rsqa#
+- Version identifier: https://w3id.org/everse/rsqa/0.0.1
+- Author: Faruk Diblen, EVERSE Consortium
+
+A repository to describe the Research Software Quality Assessment results used in the EVERSE project. This schema allows for capturing the outcomes of software quality assessments, including individual check results and their associated evidence.
+
+## Namespaces used in this document
+
+| Namespace prefix | Namespace URI |
+|---|---|
+|rsqa|[https://w3id.org/everse/rsqa#](https://w3id.org/everse/rsqa#)|
+|rsqi|[https://w3id.org/everse/rsqi#](https://w3id.org/everse/rsqi#)|
+|rs|[https://w3id.org/everse/rs#](https://w3id.org/everse/rs#)|
+|schema|[http://schema.org/](http://schema.org/)|
+|dcterms|[http://purl.org/dc/terms/](http://purl.org/dc/terms/)|
+
+## Definitions
+
+### Software Quality Assessment (rsqa:SoftwareQualityAssessment)
+
+A software quality assessment represents the result of measured indicators for a piece of software. It aggregates multiple check results that evaluate different quality indicators.
+
+The following metadata attributes define a Software Quality Assessment:
+
+| Attribute | Key (JSON-LD) | Term (mapping) | Expected value |
+|---|---|---|---|
+| Name | name | [schema:name](https://schema.org/name) | [schema:Text](https://schema.org/Text) (String) |
+| Description | description | [schema:description](https://schema.org/description) | [schema:Text](https://schema.org/Text) (String) |
+| Creator | creator | [schema:creator](https://schema.org/creator) | [schema:Person](https://schema.org/Person) or [schema:Organization](https://schema.org/Organization) |
+| Date created | dateCreated | [schema:dateCreated](https://schema.org/dateCreated) | [schema:DateTime](https://schema.org/DateTime) (String) |
+| Version | version | [schema:version](https://schema.org/version) | [schema:Text](https://schema.org/Text) (String) |
+| License | license | [schema:license](https://schema.org/license) | [schema:URL](https://schema.org/URL) (URL) |
+| Assessed software | assessedSoftware | [rsqa:assessedSoftware](https://w3id.org/everse/rsqa#assessedSoftware) | [rs:SoftwareApplication](https://w3id.org/everse/rs#SoftwareApplication) (URL) |
+| Check results | checks | [rsqa:hasCheckResult](https://w3id.org/everse/rsqa#hasCheckResult) | [rsqa:CheckResult](https://w3id.org/everse/rsqa#CheckResult) (Array) |
+
+### Check Result (rsqa:CheckResult)
+
+Represents the outcome of a specific check performed as part of a software quality assessment. It is a subclass of schema:Action, capturing the process and result of evaluating a particular quality indicator.
+
+The following metadata attributes define a Check Result:
+
+| Attribute | Key (JSON-LD) | Term (mapping) | Expected value |
+|---|---|---|---|
+| Assesses indicator | assessesIndicator | [rsqa:assessesIndicator](https://w3id.org/everse/rsqa#assessesIndicator) | [rsqi:SoftwareQualityIndicator](https://w3id.org/everse/rsqi#SoftwareQualityIndicator) (URL) |
+| Checking software | checkingSoftware | [rsqa:checkingSoftware](https://w3id.org/everse/rsqa#checkingSoftware) | [rs:SoftwareApplication](https://w3id.org/everse/rs#SoftwareApplication) |
+| Process | process | [schema:actionProcess](https://schema.org/actionProcess) | [schema:Text](https://schema.org/Text) (String) |
+| Status | status | [schema:actionStatus](https://schema.org/actionStatus) | [schema:ActionStatusType](https://schema.org/ActionStatusType) (URL) |
+| Output | output | [rsqa:checkOutput](https://w3id.org/everse/rsqa#checkOutput) | [xsd:string](http://www.w3.org/2001/XMLSchema#string) (String) |
+| Evidence | evidence | [rsqa:checkEvidence](https://w3id.org/everse/rsqa#checkEvidence) | [xsd:string](http://www.w3.org/2001/XMLSchema#string) (String) |
+
+## Properties
+
+### rsqa:assessedSoftware
+
+Links a SoftwareQualityAssessment to the SoftwareApplication that was assessed.
+
+- Domain: rsqa:SoftwareQualityAssessment
+- Range: rs:SoftwareApplication
+
+### rsqa:hasCheckResult
+
+Links a software quality assessment to its individual check results.
+
+- Domain: rsqa:SoftwareQualityAssessment
+- Range: rsqa:CheckResult
+- SubPropertyOf: schema:hasPart
+
+### rsqa:checkingSoftware
+
+The software that was used to perform the check.
+
+- Domain: rsqa:CheckResult
+- Range: rs:SoftwareApplication
+- SubPropertyOf: schema:agent
+
+### rsqa:assessesIndicator
+
+The specific quality indicator that this check assesses.
+
+- Domain: rsqa:CheckResult
+- Range: rsqi:SoftwareQualityIndicator
+- SubPropertyOf: schema:object
+
+### rsqa:checkOutput
+
+The raw output or result value of the check.
+
+- Domain: rsqa:CheckResult
+- Range: xsd:string
+- SubPropertyOf: schema:result
+
+### rsqa:checkEvidence
+
+Additional information or evidence on how the check status was concluded.
+
+- Domain: rsqa:CheckResult
+- Range: xsd:string
+- SubPropertyOf: schema:result
+
+## Example
+
+To see an example of an assessment, see the [JSON-LD file](example.json) stored in this repository.
+
+The latest version of the vocabulary is accessible at [https://w3id.org/everse/rsqa](https://w3id.org/everse/rsqa).
+
+To obtain the JSON-LD context, just perform content negotiation as follows:
+
+```
+curl -sH "accept:application/ld+json" -L https://w3id.org/everse/rsqa
+```
+
+The vocabulary has versioning enabled. To get a particular version add the version number in the URL:
+
+```
+curl -sH "accept:application/ld+json" -L https://w3id.org/everse/rsqa/0.0.1
+```

--- a/assessment/dev/README.md
+++ b/assessment/dev/README.md
@@ -1,20 +1,21 @@
 # RS Quality Assessment metadata schema
-- Version: 0.0.1
+
+- Version: 0.0.2
 - Identifier: https://w3id.org/everse/rsqa#
-- Version identifier: https://w3id.org/everse/rsqa/0.0.1
+- Version identifier: https://w3id.org/everse/rsqa/0.0.2
 - Author: Faruk Diblen, EVERSE Consortium
 
 A repository to describe the Research Software Quality Assessment results used in the EVERSE project. This schema allows for capturing the outcomes of software quality assessments, including individual check results and their associated evidence.
 
 ## Namespaces used in this document
 
-| Namespace prefix | Namespace URI |
-|---|---|
-|rsqa|[https://w3id.org/everse/rsqa#](https://w3id.org/everse/rsqa#)|
-|rsqi|[https://w3id.org/everse/rsqi#](https://w3id.org/everse/rsqi#)|
-|rs|[https://w3id.org/everse/rs#](https://w3id.org/everse/rs#)|
-|schema|[http://schema.org/](http://schema.org/)|
-|dcterms|[http://purl.org/dc/terms/](http://purl.org/dc/terms/)|
+| Namespace prefix | Namespace URI                                                  |
+| ---------------- | -------------------------------------------------------------- |
+| rsqa             | [https://w3id.org/everse/rsqa#](https://w3id.org/everse/rsqa#) |
+| rsqi             | [https://w3id.org/everse/rsqi#](https://w3id.org/everse/rsqi#) |
+| rs               | [https://w3id.org/everse/rs#](https://w3id.org/everse/rs#)     |
+| schema           | [http://schema.org/](http://schema.org/)                       |
+| dcterms          | [http://purl.org/dc/terms/](http://purl.org/dc/terms/)         |
 
 ## Definitions
 
@@ -24,16 +25,16 @@ A software quality assessment represents the result of measured indicators for a
 
 The following metadata attributes define a Software Quality Assessment:
 
-| Attribute | Key (JSON-LD) | Term (mapping) | Expected value |
-|---|---|---|---|
-| Name | name | [schema:name](https://schema.org/name) | [schema:Text](https://schema.org/Text) (String) |
-| Description | description | [schema:description](https://schema.org/description) | [schema:Text](https://schema.org/Text) (String) |
-| Creator | creator | [schema:creator](https://schema.org/creator) | [schema:Person](https://schema.org/Person) or [schema:Organization](https://schema.org/Organization) |
-| Date created | dateCreated | [schema:dateCreated](https://schema.org/dateCreated) | [schema:DateTime](https://schema.org/DateTime) (String) |
-| Version | version | [schema:version](https://schema.org/version) | [schema:Text](https://schema.org/Text) (String) |
-| License | license | [schema:license](https://schema.org/license) | [schema:URL](https://schema.org/URL) (URL) |
-| Assessed software | assessedSoftware | [rsqa:assessedSoftware](https://w3id.org/everse/rsqa#assessedSoftware) | [rs:SoftwareApplication](https://w3id.org/everse/rs#SoftwareApplication) (URL) |
-| Check results | checks | [rsqa:hasCheckResult](https://w3id.org/everse/rsqa#hasCheckResult) | [rsqa:CheckResult](https://w3id.org/everse/rsqa#CheckResult) (Array) |
+| Attribute         | Key (JSON-LD)    | Term (mapping)                                                         | Expected value                                                                                       |
+| ----------------- | ---------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Name              | name             | [schema:name](https://schema.org/name)                                 | [schema:Text](https://schema.org/Text) (String)                                                      |
+| Description       | description      | [schema:description](https://schema.org/description)                   | [schema:Text](https://schema.org/Text) (String)                                                      |
+| Creator           | creator          | [schema:creator](https://schema.org/creator)                           | [schema:Person](https://schema.org/Person) or [schema:Organization](https://schema.org/Organization) |
+| Date created      | dateCreated      | [schema:dateCreated](https://schema.org/dateCreated)                   | [schema:DateTime](https://schema.org/DateTime) (String)                                              |
+| Version           | version          | [schema:version](https://schema.org/version)                           | [schema:Text](https://schema.org/Text) (String)                                                      |
+| License           | license          | [schema:license](https://schema.org/license)                           | [schema:URL](https://schema.org/URL) (URL)                                                           |
+| Assessed software | assessedSoftware | [rsqa:assessedSoftware](https://w3id.org/everse/rsqa#assessedSoftware) | [rs:SoftwareApplication](https://w3id.org/everse/rs#SoftwareApplication) (URL)                       |
+| Check results     | checks           | [rsqa:hasCheckResult](https://w3id.org/everse/rsqa#hasCheckResult)     | [rsqa:CheckResult](https://w3id.org/everse/rsqa#CheckResult) (Array)                                 |
 
 ### Check Result (rsqa:CheckResult)
 
@@ -41,14 +42,14 @@ Represents the outcome of a specific check performed as part of a software quali
 
 The following metadata attributes define a Check Result:
 
-| Attribute | Key (JSON-LD) | Term (mapping) | Expected value |
-|---|---|---|---|
+| Attribute          | Key (JSON-LD)     | Term (mapping)                                                           | Expected value                                                                               |
+| ------------------ | ----------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
 | Assesses indicator | assessesIndicator | [rsqa:assessesIndicator](https://w3id.org/everse/rsqa#assessesIndicator) | [rsqi:SoftwareQualityIndicator](https://w3id.org/everse/rsqi#SoftwareQualityIndicator) (URL) |
-| Checking software | checkingSoftware | [rsqa:checkingSoftware](https://w3id.org/everse/rsqa#checkingSoftware) | [rs:SoftwareApplication](https://w3id.org/everse/rs#SoftwareApplication) |
-| Process | process | [schema:actionProcess](https://schema.org/actionProcess) | [schema:Text](https://schema.org/Text) (String) |
-| Status | status | [schema:actionStatus](https://schema.org/actionStatus) | [schema:ActionStatusType](https://schema.org/ActionStatusType) (URL) |
-| Output | output | [rsqa:checkOutput](https://w3id.org/everse/rsqa#checkOutput) | [xsd:string](http://www.w3.org/2001/XMLSchema#string) (String) |
-| Evidence | evidence | [rsqa:checkEvidence](https://w3id.org/everse/rsqa#checkEvidence) | [xsd:string](http://www.w3.org/2001/XMLSchema#string) (String) |
+| Checking software  | checkingSoftware  | [rsqa:checkingSoftware](https://w3id.org/everse/rsqa#checkingSoftware)   | [rs:SoftwareApplication](https://w3id.org/everse/rs#SoftwareApplication)                     |
+| Process            | process           | [schema:actionProcess](https://schema.org/actionProcess)                 | [schema:Text](https://schema.org/Text) (String)                                              |
+| Status             | status            | [schema:actionStatus](https://schema.org/actionStatus)                   | [schema:ActionStatusType](https://schema.org/ActionStatusType) (URL)                         |
+| Output             | output            | [rsqa:checkOutput](https://w3id.org/everse/rsqa#checkOutput)             | [xsd:string](http://www.w3.org/2001/XMLSchema#string) (String)                               |
+| Evidence           | evidence          | [rsqa:checkEvidence](https://w3id.org/everse/rsqa#checkEvidence)         | [xsd:string](http://www.w3.org/2001/XMLSchema#string) (String)                               |
 
 ## Properties
 
@@ -114,5 +115,5 @@ curl -sH "accept:application/ld+json" -L https://w3id.org/everse/rsqa
 The vocabulary has versioning enabled. To get a particular version add the version number in the URL:
 
 ```
-curl -sH "accept:application/ld+json" -L https://w3id.org/everse/rsqa/0.0.1
+curl -sH "accept:application/ld+json" -L https://w3id.org/everse/rsqa/0.0.2
 ```

--- a/assessment/dev/context.jsonld
+++ b/assessment/dev/context.jsonld
@@ -104,9 +104,9 @@
                 "@value": "2025-06-19T17:30:00Z",
                 "@type": "xsd:dateTime"
             },
-            "owl:versionInfo": "0.0.1",
+            "owl:versionInfo": "0.0.2",
             "rdfs:label": "Research Software Quality Assessment vocabulary",
-            "owl:versionIRI": { "@id": "https://w3id.org/everse/rsqa/0.0.1" },
+            "owl:versionIRI": { "@id": "https://w3id.org/everse/rsqa/0.0.2" },
             "license": { "@id": "https://creativecommons.org/licenses/by/4.0/" }
         }
     ]


### PR DESCRIPTION
This PR adds documentation for the assessment schema.

Ref: 
- #52 

Note: I set the version as 0.0.2 to be consistent with the other schemas. If you prefer to keep 0.0.1, I can revert that.
