### PR TITLE
add threshold and raw_value as new properties for assessment schemas

### DIFF
--- a/assessment/dev/context.jsonld
+++ b/assessment/dev/context.jsonld
@@ -100,7 +100,7 @@
             "@type": "rdf:Property",
             "rdfs:subPropertyOf": { "@id": "schema:result" },
             "rdfs:label": "check raw value",
-            "rdfs:comment": "The raw value or measurement obtained from the check, before any interpretation or thresholding.",
+            "rdfs:comment": "The raw value or measurement obtained from the check, before any interpretation or thresholding. This is different from the checkOutput property, which declares if the test is passed or not.",
             "rdfs:domain": { "@id": "rsqa:CheckResult" },
             "rdfs:range": { "@id": "xsd:string" }
         },
@@ -109,7 +109,7 @@
             "@type": "rdf:Property",
             "rdfs:subPropertyOf": { "@id": "schema:result" },
             "rdfs:label": "check threshold",
-            "rdfs:comment": "The threshold or criteria used to interpret the raw value of the check.",
+            "rdfs:comment": "The threshold or criteria used to interpret the raw value of the check. For example, documentation coverage passes under a tool if at least 50 percent of the functions are documented",
             "rdfs:domain": { "@id": "rsqa:CheckResult" },
             "rdfs:range": { "@id": "xsd:string" }
         },

--- a/assessment/dev/context.jsonld
+++ b/assessment/dev/context.jsonld
@@ -19,6 +19,8 @@
         "status": { "@id": "schema:actionStatus", "@type": "@id" },
         "process": { "@id": "schema:actionProcess", "@type": "@id" },
         "output": "rsqa:checkOutput",
+        "raw_value": "rsqa:checkRawValue",
+        "threshold": "rsqa:checkThreshold",
         "evidence": "rsqa:checkEvidence",
         "SoftwareQualityAssessment": "rsqa:SoftwareQualityAssessment",
         "CheckResult": "rsqa:CheckResult",
@@ -90,6 +92,24 @@
             "rdfs:subPropertyOf": { "@id": "schema:result" },
             "rdfs:label": "check evidence",
             "rdfs:comment": "Additional information or evidence on how the check status was concluded.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "xsd:string" }
+        },
+                {
+            "@id": "rsqa:checkRawValue",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:result" },
+            "rdfs:label": "check raw value",
+            "rdfs:comment": "The raw value or measurement obtained from the check, before any interpretation or thresholding.",
+            "rdfs:domain": { "@id": "rsqa:CheckResult" },
+            "rdfs:range": { "@id": "xsd:string" }
+        },
+        {
+            "@id": "rsqa:checkThreshold",
+            "@type": "rdf:Property",
+            "rdfs:subPropertyOf": { "@id": "schema:result" },
+            "rdfs:label": "check threshold",
+            "rdfs:comment": "The threshold or criteria used to interpret the raw value of the check.",
             "rdfs:domain": { "@id": "rsqa:CheckResult" },
             "rdfs:range": { "@id": "xsd:string" }
         },


### PR DESCRIPTION
linked to #62 

still need to update the example accordingly

I am not very familiar with the jsonld format so this PR is very minimal.

I don't know how to handle scenarios where checkResult is not using any threshold and numerical raw_value

For example: howfairis has_license is returning "valid" if it found a license so it would be the "raw_value" but no threshold is used as this is not numerical value. It just check if output == "valid" to pass "true" to the property "output" of the assessment schema. 